### PR TITLE
Fix: popping an empty array crashes the script

### DIFF
--- a/lib/screenCapturer.js
+++ b/lib/screenCapturer.js
@@ -54,8 +54,7 @@ module.exports = {
      */
     saveScreenshots: function(url, host, devices, saveLocation) {
         function saveScreenshot() {
-            var device = devices.pop();
-
+            var device = devices.length > 0 ? devices.pop() : null;
             if (device) {
                 saveScreenshotDevice(url, host, device, saveLocation, saveScreenshot);
             } else {


### PR DESCRIPTION
The script will never exit unless this is checked before `pop()`!
